### PR TITLE
Fix crash when loading news feed

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/NewsFragment.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/NewsFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import android.widget.Toast
 import gr.hmu.hmuapp.data.fetchRss
 import gr.hmu.hmuapp.databinding.FragmentNewsBinding
 import kotlinx.coroutines.launch
@@ -38,8 +39,12 @@ class NewsFragment : Fragment() {
         binding.newsList.adapter = adapter
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val items = fetchRss("https://ee.hmu.gr/feed/")
-            adapter.submitList(items)
+            try {
+                val items = fetchRss("https://ee.hmu.gr/feed/")
+                adapter.submitList(items)
+            } catch (e: Exception) {
+                Toast.makeText(requireContext(), R.string.fetch_failed, Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -8,4 +8,5 @@
     <string name="title_home">Αρχική</string>
     <string name="welcome_message">Καλώς ήρθατε στην εφαρμογή HMU</string>
     <string name="coming_soon">Έρχεται σύντομα</string>
+    <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7,4 +7,5 @@
     <string name="title_student_links">Student Links</string>
     <string name="title_map">Map</string>
     <string name="coming_soon">Coming Soon</string>
+    <string name="fetch_failed">Failed to load news</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="title_student_links">Σύνδεσμοι Φοιτητών</string>
     <string name="title_map">Χάρτης</string>
     <string name="coming_soon">Έρχεται σύντομα</string>
+    <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
 </resources>


### PR DESCRIPTION
## Summary
- handle errors when fetching the RSS feed
- show a toast if news can't be loaded
- add translated string for the error message

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aad0faa088332b675a9ba9146f39b