### PR TITLE
Add swipe refresh to news list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,5 +46,6 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.7.7'
     implementation 'androidx.navigation:navigation-ui-ktx:2.7.7'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="gr.hmu.hmuapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/news_list"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipe_refresh"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"/>
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/news_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -9,4 +9,5 @@
     <string name="welcome_message">Καλώς ήρθατε στην εφαρμογή HMU</string>
     <string name="coming_soon">Έρχεται σύντομα</string>
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
+    <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8,4 +8,5 @@
     <string name="title_map">Map</string>
     <string name="coming_soon">Coming Soon</string>
     <string name="fetch_failed">Failed to load news</string>
+    <string name="no_internet">No internet connection</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="title_map">Χάρτης</string>
     <string name="coming_soon">Έρχεται σύντομα</string>
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
+    <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
 </resources>


### PR DESCRIPTION
## Summary
- refresh News with SwipeRefreshLayout
- handle missing network connection with toast message
- add SwipeRefreshLayout dependency
- add permission for network state access

## Testing
- `gradle tasks --all`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab9e47c3883329953a3fda5792fbd