### PR TITLE
Fix null check in HTML parser

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
@@ -16,8 +16,8 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
         .get()
     val items = mutableListOf<RssItem>()
     for (titleDiv in doc.select("div.contenttitle")) {
-        val linkEl = titleDiv.selectFirst("a")
-        val title = linkEl?.text()?.trim().orEmpty()
+        val linkEl = titleDiv.selectFirst("a") ?: continue
+        val title = linkEl.text().trim()
         if (title.isBlank()) continue
         val link = linkEl.absUrl("href")
         val parent = titleDiv.parent()


### PR DESCRIPTION
## Summary
- skip entries without `<a>` tag when parsing the news HTML

## Testing
- `gradle assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac0612d5083328b32ec758ae79c31