### PR TITLE
Fix news parsing when link is missing

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
@@ -19,7 +19,7 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
         val linkEl = titleDiv.selectFirst("a")
         val title = linkEl?.text()?.trim().orEmpty()
         if (title.isBlank()) continue
-        val link = linkEl.absUrl("href")
+        val link = linkEl?.absUrl("href").orEmpty()
         val parent = titleDiv.parent()
         val date = parent?.selectFirst("div.date")?.text()?.trim().orEmpty()
         items.add(RssItem(title, date, link))


### PR DESCRIPTION
## Summary
- avoid dropping items entirely if the `<a>` tag is missing

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_684ac0612d5083328b32ec758ae79c31