### PR TITLE
Fix HTML news parsing

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
@@ -15,7 +15,6 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
             .referrer("https://www.google.com")
             .header("Accept-Language", "el,en;q=0.9")
             .ignoreHttpErrors(true)
-            .validateTLSCertificates(false)
             .timeout(10_000)
             .method(Connection.Method.GET)
             .followRedirects(true)


### PR DESCRIPTION
## Summary
- remove usage of removed `validateTLSCertificates` from Jsoup

## Testing
- `gradle :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac53b91048332a367742f92a8569c