### PR TITLE
Fix HTML news parsing

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/HtmlNewsService.kt
@@ -15,7 +15,6 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
             .referrer("https://www.google.com")
             .header("Accept-Language", "el,en;q=0.9")
             .ignoreHttpErrors(true)
-            .validateTLSCertificates(false)
             .timeout(10_000)
             .method(Connection.Method.GET)
             .followRedirects(true)
@@ -23,7 +22,30 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
     } catch (e: Exception) {
         return@withContext emptyList()
     }
+
+    // Try to locate an RSS feed link first for more reliable parsing
+    val rssLink = doc.selectFirst("link[type=application/rss+xml]")?.absUrl("href")
+    if (!rssLink.isNullOrBlank()) {
+        return@withContext fetchRss(rssLink)
+    }
+
     val items = mutableListOf<RssItem>()
+
+    // Prefer modern <article> markup if present
+    val articles = doc.select("article")
+    if (articles.isNotEmpty()) {
+        for (article in articles) {
+            val linkEl = article.selectFirst("h1 a, h2 a, h3 a, a")
+            val title = linkEl?.text()?.trim().orEmpty()
+            if (title.isBlank()) continue
+            val date = article.selectFirst("time, .date")?.text()?.trim().orEmpty()
+            val link = linkEl.absUrl("href")
+            items.add(RssItem(title, date, link))
+        }
+        return@withContext items
+    }
+
+    // Fallback to older div based markup
     for (titleDiv in doc.select("div.contenttitle")) {
         val linkEl = titleDiv.selectFirst("a")
         val title = linkEl?.text()?.trim()?.takeIf { it.isNotBlank() }
@@ -34,5 +56,6 @@ suspend fun fetchNews(): List<RssItem> = withContext(Dispatchers.IO) {
         val date = parent?.selectFirst("div.date")?.text()?.trim().orEmpty()
         items.add(RssItem(title, date, link))
     }
+
     items
 }


### PR DESCRIPTION
## Summary
- remove usage of removed `validateTLSCertificates` from Jsoup
- check for RSS feed links and parse feed when available
- add fallback article parsing for modern markup

## Testing
- `gradle :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac53b91048332a367742f92a8569c