### PR TITLE
Fix Teachers tab empty state

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/TeachersFragment.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/TeachersFragment.kt
@@ -4,6 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -68,10 +73,36 @@ class TeachersFragment : Fragment() {
     }
 
     private fun loadTeachers() {
+        if (!hasInternetConnection()) {
+            binding.emptyView.visibility = View.VISIBLE
+            Toast.makeText(requireContext(), R.string.no_internet, Toast.LENGTH_LONG).show()
+            return
+        }
         viewLifecycleOwner.lifecycleScope.launch {
-            val teachers = fetchTeachers()
-            allTeachers = teachers
-            adapter.submitList(teachers)
+            try {
+                val teachers = fetchTeachers()
+                allTeachers = teachers
+                adapter.submitList(teachers)
+                binding.emptyView.visibility = if (teachers.isEmpty()) View.VISIBLE else View.GONE
+                if (teachers.isEmpty()) {
+                    Toast.makeText(requireContext(), R.string.teachers_load_failed, Toast.LENGTH_LONG).show()
+                }
+            } catch (e: Exception) {
+                binding.emptyView.visibility = View.VISIBLE
+                Toast.makeText(requireContext(), R.string.teachers_load_failed, Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    private fun hasInternetConnection(): Boolean {
+        val cm = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = cm.activeNetwork ?: return false
+            val capabilities = cm.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } else {
+            val networkInfo = cm.activeNetworkInfo ?: return false
+            networkInfo.isConnected
         }
     }
 

--- a/app/src/main/res/layout/fragment_teachers.xml
+++ b/app/src/main/res/layout/fragment_teachers.xml
@@ -17,4 +17,13 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:text="@string/no_teachers_found"
+        android:visibility="gone" />
 </LinearLayout>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -10,4 +10,6 @@
     <string name="coming_soon">Έρχεται σύντομα</string>
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
+    <string name="teachers_load_failed">Αποτυχία φόρτωσης καθηγητών</string>
+    <string name="no_teachers_found">Δεν βρέθηκαν διδάσκοντες</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -10,4 +10,6 @@
     <string name="fetch_failed">Failed to load news</string>
     <string name="no_internet">No internet connection</string>
     <string name="search_teachers">Search...</string>
+    <string name="teachers_load_failed">Failed to load teachers</string>
+    <string name="no_teachers_found">No teachers found</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
     <string name="search_teachers">Αναζήτηση...</string>
+    <string name="teachers_load_failed">Αποτυχία φόρτωσης καθηγητών</string>
+    <string name="no_teachers_found">Δεν βρέθηκαν διδάσκοντες</string>
 </resources>


### PR DESCRIPTION
## Summary
- show an empty view when no teachers are loaded
- add English and Greek strings for failed teacher loading
- check for internet connectivity in `TeachersFragment`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29f5ddc48332b46a7298a4cc97f8