### PR TITLE
Fix Teachers tab empty state

### DIFF
--- a/app/src/main/java/gr/hmu/hmuapp/TeachersAdapter.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/TeachersAdapter.kt
@@ -35,11 +35,17 @@ class TeachersAdapter(
         private val name: TextView = view.findViewById(R.id.name)
         private val title: TextView = view.findViewById(R.id.title)
         private val department: TextView = view.findViewById(R.id.department)
+        private val phone: TextView = view.findViewById(R.id.phone)
+        private val email: TextView = view.findViewById(R.id.email)
+        private val interests: TextView = view.findViewById(R.id.interests)
 
         fun bind(item: Teacher) {
             name.text = item.name
             title.text = item.title
             department.text = item.department
+            phone.text = item.phone
+            email.text = item.email
+            interests.text = item.interests
             itemView.setOnClickListener { onItemClick(item) }
         }
     }

--- a/app/src/main/java/gr/hmu/hmuapp/TeachersFragment.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/TeachersFragment.kt
@@ -4,6 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -68,10 +73,36 @@ class TeachersFragment : Fragment() {
     }
 
     private fun loadTeachers() {
+        if (!hasInternetConnection()) {
+            binding.emptyView.visibility = View.VISIBLE
+            Toast.makeText(requireContext(), R.string.no_internet, Toast.LENGTH_LONG).show()
+            return
+        }
         viewLifecycleOwner.lifecycleScope.launch {
-            val teachers = fetchTeachers()
-            allTeachers = teachers
-            adapter.submitList(teachers)
+            try {
+                val teachers = fetchTeachers()
+                allTeachers = teachers
+                adapter.submitList(teachers)
+                binding.emptyView.visibility = if (teachers.isEmpty()) View.VISIBLE else View.GONE
+                if (teachers.isEmpty()) {
+                    Toast.makeText(requireContext(), R.string.teachers_load_failed, Toast.LENGTH_LONG).show()
+                }
+            } catch (e: Exception) {
+                binding.emptyView.visibility = View.VISIBLE
+                Toast.makeText(requireContext(), R.string.teachers_load_failed, Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    private fun hasInternetConnection(): Boolean {
+        val cm = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = cm.activeNetwork ?: return false
+            val capabilities = cm.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } else {
+            val networkInfo = cm.activeNetworkInfo ?: return false
+            networkInfo.isConnected
         }
     }
 

--- a/app/src/main/java/gr/hmu/hmuapp/data/Teacher.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/Teacher.kt
@@ -4,5 +4,8 @@ data class Teacher(
     val name: String,
     val title: String,
     val department: String,
+    val phone: String,
+    val email: String,
+    val interests: String,
     val profileUrl: String
 )

--- a/app/src/main/java/gr/hmu/hmuapp/data/TeacherService.kt
+++ b/app/src/main/java/gr/hmu/hmuapp/data/TeacherService.kt
@@ -7,6 +7,27 @@ import org.jsoup.Connection
 
 private const val TEACHERS_URL = "https://ee.hmu.gr/meli-dep/"
 
+private fun parseTeacherDetails(url: String): Triple<String, String, String> {
+    return try {
+        val doc = Jsoup.connect(url)
+            .userAgent("Mozilla/5.0")
+            .header("Accept-Language", "el,en;q=0.9")
+            .ignoreHttpErrors(true)
+            .timeout(10_000)
+            .method(Connection.Method.GET)
+            .followRedirects(true)
+            .get()
+
+        val phone = doc.selectFirst("a[href^=tel], p:matches((?i)τηλ|phone)")?.text()?.trim().orEmpty()
+        val email = doc.selectFirst("a[href^=mailto]")?.attr("href")?.removePrefix("mailto:")
+            ?: doc.selectFirst("p:matches((?i)e.?mail)")?.text()?.substringAfter(":")?.trim().orEmpty()
+        val interests = doc.selectFirst("p:matches(Ερευνητικ|Research)")?.text()?.substringAfter(":")?.trim().orEmpty()
+        Triple(phone, email, interests)
+    } catch (e: Exception) {
+        Triple("", "", "")
+    }
+}
+
 suspend fun fetchTeachers(): List<Teacher> = withContext(Dispatchers.IO) {
     val doc = try {
         Jsoup.connect(TEACHERS_URL)
@@ -32,7 +53,8 @@ suspend fun fetchTeachers(): List<Teacher> = withContext(Dispatchers.IO) {
         val title = el.selectFirst("p:matches((?i)prof|καθηγη|επικουρ|Λέκτορ), span:matches((?i)prof|καθηγη|επικουρ|Λέκτορ)")?.text()?.trim().orEmpty()
         val department = el.selectFirst("p:matches((?i)department|τμήμα)")?.text()?.trim().orEmpty()
         val link = el.selectFirst("a[href]")?.absUrl("href").orEmpty()
-        teachers.add(Teacher(name, title, department, link))
+        val (phone, email, interests) = if (link.isNotEmpty()) parseTeacherDetails(link) else Triple("", "", "")
+        teachers.add(Teacher(name, title, department, phone, email, interests, link))
     }
 
     teachers

--- a/app/src/main/res/layout/fragment_teachers.xml
+++ b/app/src/main/res/layout/fragment_teachers.xml
@@ -17,4 +17,13 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:text="@string/no_teachers_found"
+        android:visibility="gone" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_teacher.xml
+++ b/app/src/main/res/layout/item_teacher.xml
@@ -34,5 +34,24 @@
             android:layout_height="wrap_content"
             android:textAppearance="?attr/textAppearanceBodySmall"
             android:textColor="@android:color/darker_gray" />
+
+        <TextView
+            android:id="@+id/phone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodySmall" />
+
+        <TextView
+            android:id="@+id/email"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autoLink="email"
+            android:textAppearance="?attr/textAppearanceBodySmall" />
+
+        <TextView
+            android:id="@+id/interests"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodySmall" />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -10,4 +10,6 @@
     <string name="coming_soon">Έρχεται σύντομα</string>
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
+    <string name="teachers_load_failed">Αποτυχία φόρτωσης καθηγητών</string>
+    <string name="no_teachers_found">Δεν βρέθηκαν διδάσκοντες</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -10,4 +10,6 @@
     <string name="fetch_failed">Failed to load news</string>
     <string name="no_internet">No internet connection</string>
     <string name="search_teachers">Search...</string>
+    <string name="teachers_load_failed">Failed to load teachers</string>
+    <string name="no_teachers_found">No teachers found</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="fetch_failed">Αποτυχία φόρτωσης ειδήσεων</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
     <string name="search_teachers">Αναζήτηση...</string>
+    <string name="teachers_load_failed">Αποτυχία φόρτωσης καθηγητών</string>
+    <string name="no_teachers_found">Δεν βρέθηκαν διδάσκοντες</string>
 </resources>


### PR DESCRIPTION
## Summary
- show an empty view when no teachers are loaded
- add English and Greek strings for failed teacher loading
- check for internet connectivity in `TeachersFragment`
- parse phone, email, research interests for each teacher and display them

## Testing
- `./gradlew assembleDebug` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b29f5ddc48332b46a7298a4cc97f8